### PR TITLE
Prevent <feature> inside <feature>

### DIFF
--- a/src/Nodes/Product/Features.php
+++ b/src/Nodes/Product/Features.php
@@ -51,7 +51,7 @@ class Features implements Contracts\NodeInterface
      * @Serializer\Expose
      * @Serializer\SerializedName("FEATURE")
      * @Serializer\Type("array<Naugrim\BMEcat\Nodes\Product\Feature>")
-     * @Serializer\XmlList( entry="FEATURE")
+     * @Serializer\XmlList( inline = true, entry="FEATURE")
      *
      * @var Feature[]
      */


### PR DESCRIPTION
With current code you will get 
```xml
<PRODUCT_FEATURES>
  <FEATURE>
    <FEATURE>
      <FNAME><![CDATA[Feature name]]></FNAME>
      <FVALUE><![CDATA[Feature value]]></FVALUE>
    </FEATURE>
  </FEATURE>
</PRODUCT_FEATURES>
```

when doing:
```php
...
$productFeatures = new \Naugrim\BMEcat\Nodes\Product\Features();
$productNode->addFeatures($productFeatures);
$productFeature = new \Naugrim\BMEcat\Nodes\Product\Feature();
$productFeature->setName('Feature name');
$productFeature->setValue('Feature value');
$productFeatures->addFeature($productFeature);
```